### PR TITLE
Redefine consistency and update examples

### DIFF
--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -358,7 +358,7 @@ which is a procedure where a client encrypt the information that it sends to a s
 or signed object generated with the server keys. This encryption uses a key derived from the key
 configuration, specifically not including any form of key identifier along with the encrypted
 information. If key derivation for the encryption uses a pre-image resistant function (like HKDF),
-the server can only decrypt the information if it knows the key configuration. As there is no
+the server can only decrypt the information only if it either knows the key configuration or can guess it. As there is no
 information the server can use to identify which key was used, it is forced to perform trial
 decryption if it wants to use multiple keys.
 

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -141,7 +141,7 @@ no restrictions on whether the clients holding those keys are the same.
 
 There are two different predicates for consistency, defined below.
 
-- Consistency: Two key sets with the same set ID are consistent iff the intersection
+- Consistency: Two key sets with the same set ID are consistent if and only if (iff) the intersection
   of key IDs for each set is non-empty.
 - Global consistency: A key set is globally consistent iff, for all key sets with the
   same set ID, the set of key IDs intersects with the key IDs of the candidate key set.

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -151,7 +151,7 @@ consists in applying a verification function to those sets. If the two sets are 
 and the union of those two sets is equal to the set of all possible honestly generated values,
 then the union is globally consistent.
 
-Consistency checks can happen within a reliant system or out of it. We refer to these
+Consistency checks can happen within a reliant system, i.e., as part of the protocol in which consistency is preferred, or out of it, i.e., a separate protocol run alongside the reliant system. We refer to these
 two paths as in-band and out-of-band verification. In-band verification is a check
 which is invoked as part of a reliant system. This type of verification is only achieved
 by participants of the reliant system. In contrast, out-of-band verifiability is a check

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -144,7 +144,7 @@ There are two different predicates for consistency, defined below.
 - Consistency: Two key sets with the same set ID are consistent if and only if (iff) the intersection
   of key IDs for each set is non-empty.
 - Global consistency: A key set is globally consistent iff, for all key sets with the
-  same set ID, the set of key IDs intersects with the key IDs of the candidate key set.
+  same set ID, the intersection between each set of key IDs and each other set is non-empty.
 
 Checking for consistency or global consistency of two sets of key sets (singletons or not)
 consists in applying a verification function to those sets. If the two sets are consistent

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -250,7 +250,7 @@ impose bandwidth costs on each client that may be impractical.
 
 If this cache is trusted, then all clients which request a key from this server are
 assured they have a consistent view of the server key compared to all other clients of
-the cache. If this cache is not trusted, operational risks may arise:
+the cache. A malicious cache can introduce the following threats:
 
 - The cache can collude with the server to give per-client keys to clients.
 - The cache can give all clients a key owned by the cache, and either collude with the server to use this

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -176,7 +176,7 @@ that availability is preferred to total consistency.
 # Consistency Mechanisms
 
 There are a variety of ways in which reliant systems may build key consistency solutions,
-ranging in operational complexity to ease-of-implementation. In this section, we survey
+with different trade-offs for operational and implementation complexity. In this section, we survey
 a number of possible solutions. The viability of each varies depending on the applicable
 threat model, external dependencies, and overall reliant system's requirements.
 

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -323,7 +323,7 @@ cache directly with the server, as shown in the figure below.
 Ideally, clients confirm with the server via some anonymizing proxy. Examples of proxies
 include anonymous systems such as Tor. Tor proxies are general purpose and operate
 at a lower layer, on arbitrary communication flows, and therefore they are oblivious
-to clients fetching keys. A large set of untrusted proxies that are aware of key fetch
+to clients fetching keys. Untrusted proxies that are aware of key fetch
 requests ({{cache-based}}) may be used in a similar way. Depending on how clients
 fetch such keys from servers, it may become more difficult for servers to uniquely
 target individual clients with unique keys without detection. This is especially true

--- a/draft-ietf-privacypass-key-consistency.md
+++ b/draft-ietf-privacypass-key-consistency.md
@@ -141,17 +141,18 @@ no restrictions on whether the clients holding those keys are the same.
 
 There are two different predicates for consistency, defined below.
 
-- Consistency: Two key sets with the same set ID are consistent if and only if (iff) the intersection
-  of key IDs for each set is non-empty.
-- Global consistency: A key set is globally consistent iff, for all key sets with the
-  same set ID, the intersection between each set of key IDs and each other set is non-empty.
+- Consistency: Two key sets with the same set ID are consistent if and only if (iff) the
+  sets are equal.
+- Global consistency: A key set X is globally consistent iff, for all key sets Y with the
+  same set ID, the X and Y are consistent.
 
-Checking for consistency or global consistency of two sets of key sets (singletons or not)
+Checking for consistency or global consistency of two key sets (singletons or not)
 consists in applying a verification function to those sets. If the two sets are consistent
 and the union of those two sets is equal to the set of all possible honestly generated values,
 then the union is globally consistent.
 
-Consistency checks can happen within a reliant system, i.e., as part of the protocol in which consistency is preferred, or out of it, i.e., a separate protocol run alongside the reliant system. We refer to these
+Consistency checks can happen within a reliant system, i.e., as part of the protocol in
+which consistency is preferred, or out of it, i.e., a separate protocol run alongside the reliant system. We refer to these
 two paths as in-band and out-of-band verification. In-band verification is a check
 which is invoked as part of a reliant system. This type of verification is only achieved
 by participants of the reliant system. In contrast, out-of-band verifiability is a check


### PR DESCRIPTION
This change updates the definitions we have of consistency based on discussions that took place in the design team. It drops the notion of correctness, with the intention of replacing that with something like authenticity. Freshness was suggested on the list, but I think that's a separate issue. This PR is the basis of a more complete form of DoubleCheck, specified [here](https://github.com/chris-wood/draft-group-privacypass-k-check).